### PR TITLE
Baseline update

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,0 +1,7 @@
+[flake8]
+# Recommend matching the black line length (default 88),
+# rather than using the flake8 default of 79:
+max-line-length = 88
+extend-ignore =
+    # See https://github.com/PyCQA/pycodestyle/issues/373
+    E203,

--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -29,6 +29,3 @@ jobs:
     - name: Test with pytest
       run: |
         pytest
-    - name: Run simple baseline
-      run: |
-        python heareval/baseline.py

--- a/heareval/baseline.py
+++ b/heareval/baseline.py
@@ -59,16 +59,6 @@ class RandomProjectionMelEmbedding(torch.nn.Module):
         return embedding
 
 
-def input_sample_rate() -> int:
-    """
-    Returns:
-        One of the following values: [16000, 22050, 44100, 48000].
-            To avoid resampling on-the-fly, we will query your model
-            to find out what sample rate audio to provide it.
-    """
-    return RandomProjectionMelEmbedding.sample_rate
-
-
 def load_model(
     model_file_path: str, device: str = "cpu"
 ) -> Tuple[torch.nn.Module, Dict[str, Any]]:

--- a/heareval/baseline.py
+++ b/heareval/baseline.py
@@ -226,11 +226,11 @@ def get_audio_embedding(
     # Iterate over all batches and accumulate the embeddings for each frame.
     model.eval()
     with torch.no_grad():
-        embeddings = [model(batch[0]) for batch in loader]
+        embeddings_list = [model(batch[0]) for batch in loader]
 
     # Concatenate mini-batches back together and unflatten the frames
     # to reconstruct the audio batches
-    embeddings = torch.cat(embeddings, dim=0)
+    embeddings = torch.cat(embeddings_list, dim=0)
     embeddings = embeddings.unflatten(0, (audio_batches, num_frames))
 
     return embeddings, timestamps

--- a/heareval/baseline.py
+++ b/heareval/baseline.py
@@ -60,7 +60,7 @@ class RandomProjectionMelEmbedding(torch.nn.Module):
 
 
 def load_model(
-    model_file_path: str, device: str = "cpu"
+    model_file_path: str = "basic", device: str = "cpu"
 ) -> Tuple[torch.nn.Module, Dict[str, Any]]:
     """
     In this baseline, we don't load anything from disk.

--- a/heareval/baseline.py
+++ b/heareval/baseline.py
@@ -234,20 +234,3 @@ def pairwise_distance(emb1: Tensor, emb2: Tensor) -> Tensor:
     d = torch.cdist(emb1, emb2, p=1.0)
     assert d.shape == (emb1.shape[0], emb2.shape[0])
     return d
-
-
-if __name__ == "__main__":
-    if torch.cuda.is_available():
-        device = "cuda:0"
-    else:
-        device = "cpu"
-    model = load_model("", device=device)
-    # White noise
-    audio = torch.rand(1024, 20000, device=device) * 2 - 1
-    embs, timestamps = get_audio_embedding(
-        audio=audio,
-        model=model,
-        frame_rate=RandomProjectionMelEmbedding.sample_rate / 1000,
-    )
-
-    pairwise_distance(embs[20].float(), embs[20].float())

--- a/heareval/model/baseline.py
+++ b/heareval/model/baseline.py
@@ -80,11 +80,6 @@ def load_model(model_file_path: str = "", device: str = "cpu") -> torch.nn.Modul
     Returns:
         Model: torch.nn.Module loaded on the specified device.
     """
-
-    # We would expect that model_file_path is the location of a saved model containing
-    # model weights that we would reload. For the baseline model we have a non-learned
-    # 'basic' version, so that can be specified. If a filename is passed in then the
-    # the learned version of the baseline will be loaded.
     if model_file_path == "":
         model = RandomProjectionMelEmbedding().to(device)
     else:

--- a/heareval/model/baseline.py
+++ b/heareval/model/baseline.py
@@ -14,12 +14,9 @@ from torch import Tensor
 
 
 class RandomProjectionMelEmbedding(torch.nn.Module):
-    # sample rate, embedding size, and version number are
-    # required model attributes for the HEAR API
-    # TODO how do we want to handle version?
+    # sample rate and embedding size are required model attributes for the HEAR API
     sample_rate = 44100
     embedding_size = 4096
-    version = "0.0.1"
 
     # These attributes are specific to this baseline model
     n_fft = 4096

--- a/heareval/task_embeddings.py
+++ b/heareval/task_embeddings.py
@@ -25,7 +25,6 @@ TODO:
 import csv
 import glob
 import os.path
-import pickle
 from importlib import import_module
 from typing import Any, Dict, Tuple
 
@@ -37,10 +36,10 @@ from tqdm.auto import tqdm
 
 # This could instead be something from the participants
 EMBEDDING_PIP = "heareval.baseline"
-EMBEDDING_MODEL_PATH = ""  # Not used by baseline
+EMBEDDING_MODEL_PATH = "basic"  # Use the basic baseline
 
 # TODO: Support for multiple GPUs?
-device = "gpu" if torch.cuda.is_available() else "cpu"
+device = "cuda" if torch.cuda.is_available() else "cpu"
 
 EMBED = import_module(EMBEDDING_PIP)
 
@@ -72,33 +71,30 @@ class CSVDataset(Dataset):
         return self.rows[idx]
 
 
-# These is a high-level wrappers on the basic API that we might
+# High-level wrapper on the basic API that we might
 # consider sharing among all participants.
-
-
 def get_audio_embedding_numpy(
     audio_numpy: np.ndarray,
     model: Any,
     frame_rate: float,
 ) -> Tuple[Dict[int, np.ndarray], np.ndarray]:
-    embedding_dict, timestamps = EMBED.get_audio_embedding(  # type: ignore
+    embedding, timestamps = EMBED.get_audio_embedding(  # type: ignore
         torch.tensor(audio_numpy, device=device),
         model=model,
         frame_rate=frame_rate,
     )
-    for key in embedding_dict.keys():
-        embedding_dict[key] = embedding_dict[key].detach().cpu().numpy()
+    embedding = embedding.detach().cpu().numpy()
     timestamps = timestamps.detach().cpu().numpy()
-    return embedding_dict, timestamps
+    return embedding, timestamps
 
 
 def task_embeddings():
-    model = EMBED.load_model(EMBEDDING_MODEL_PATH, device=device)  # type: ignore
+    model, meta = EMBED.load_model(EMBEDDING_MODEL_PATH, device=device)  # type: ignore
 
     # TODO: Would be good to include the version here
     # https://github.com/neuralaudio/hear2021-eval-kit/issues/37
     embeddir = os.path.join("embeddings", EMBED.__name__)  # type: ignore
-    embedsr = EMBED.input_sample_rate()  # type: ignore
+    embed_sr = meta["sample_rate"]
 
     for task in glob.glob("tasks/*"):
         # TODO: We should be reading the metadata that describes
@@ -108,6 +104,8 @@ def task_embeddings():
 
         # TODO: Include "val" ?
         for split in ["train", "test"]:
+            print(f"Getting embeddings for {split} split:")
+
             # TODO: We might consider skipping files that already
             # have embeddings on disk, for speed
             dataloader = DataLoader(
@@ -123,23 +121,18 @@ def task_embeddings():
                 audios = []
                 for f in files:
                     x, sr = sf.read(
-                        os.path.join(task, str(embedsr), split, f), dtype=np.float32
+                        os.path.join(task, str(embed_sr), split, f), dtype=np.float32
                     )
-                    assert sr == embedsr
+                    assert sr == embed_sr
                     audios.append(x)
+
                 audios = np.vstack(audios)
-                embedding_dict, timestamps = get_audio_embedding_numpy(
+                embedding, timestamps = get_audio_embedding_numpy(
                     audios, model=model, frame_rate=frame_rate
                 )
+
                 for i, filename in enumerate(files):
-                    file_embedding_dict = {
-                        emb_size: embedding_dict[emb_size][i]
-                        for emb_size in embedding_dict
-                    }
-                    pickle.dump(
-                        file_embedding_dict,
-                        open(os.path.join(outdir, filename + ".pkl"), "wb"),
-                    )
+                    np.save(os.path.join(outdir, f"{filename}.npy"), embedding[i])
 
 
 if __name__ == "__main__":

--- a/heareval/task_embeddings.py
+++ b/heareval/task_embeddings.py
@@ -35,8 +35,8 @@ from torch.utils.data import DataLoader, Dataset
 from tqdm.auto import tqdm
 
 # This could instead be something from the participants
-EMBEDDING_PIP = "heareval.baseline"
-EMBEDDING_MODEL_PATH = "basic"  # Use the basic baseline
+EMBEDDING_PIP = "heareval.model.baseline"
+EMBEDDING_MODEL_PATH = ""  # Baseline doesn't load model
 
 # TODO: Support for multiple GPUs?
 device = "cuda" if torch.cuda.is_available() else "cpu"
@@ -89,12 +89,12 @@ def get_audio_embedding_numpy(
 
 
 def task_embeddings():
-    model, meta = EMBED.load_model(EMBEDDING_MODEL_PATH, device=device)  # type: ignore
+    model = EMBED.load_model(EMBEDDING_MODEL_PATH, device=device)  # type: ignore
 
     # TODO: Would be good to include the version here
     # https://github.com/neuralaudio/hear2021-eval-kit/issues/37
     embeddir = os.path.join("embeddings", EMBED.__name__)  # type: ignore
-    embed_sr = meta["sample_rate"]
+    embed_sr = model.sample_rate
 
     for task in glob.glob("tasks/*"):
         # TODO: We should be reading the metadata that describes

--- a/tests/test_baseline.py
+++ b/tests/test_baseline.py
@@ -41,10 +41,8 @@ class TestEmbeddingsTimestamps:
             frame_rate=input_sample_rate() / 256,
             batch_size=512,
         )
-        for embeddinga, embeddingb in zip(
-            self.embeddings_ct.values(), embeddings_ct.values()
-        ):
-            assert torch.all(torch.abs(embeddinga - embeddingb) < 1e-5)
+
+        assert torch.allclose(self.embeddings_ct, embeddings_ct)
 
     def test_embeddings_batched(self):
         # methodA - Pass two audios individually and get embeddings. methodB -
@@ -74,10 +72,7 @@ class TestEmbeddingsTimestamps:
             batch_size=512,
         )
 
-        for embeddinga, embeddingb, embeddingab in zip(
-            embeddingsa.values(), embeddingsb.values(), embeddingsab.values()
-        ):
-            assert torch.allclose(torch.cat([embeddinga, embeddingb]), embeddingab)
+        assert torch.allclose(torch.cat([embeddingsa, embeddingsb]), embeddingsab)
 
     def test_embeddings_sliced(self):
         # Slice the audio to select every even audio in the batch. Produce the
@@ -108,10 +103,8 @@ class TestEmbeddingsTimestamps:
             frame_rate=input_sample_rate() / 256,
             batch_size=512,
         )
-        for embedding_sliced, embedding_ct in zip(
-            embeddings_sliced.values(), self.embeddings_ct.values()
-        ):
-            assert torch.allclose(embedding_sliced, embedding_ct[::2])
+
+        assert torch.allclose(embeddings_sliced, self.embeddings_ct[::2])
 
     def test_embeddings_shape(self):
         # Test the embeddings shape.
@@ -119,23 +112,15 @@ class TestEmbeddingsTimestamps:
         # num_frames to be equal to the number of full audio frames that can fit into
         # the audio sample. The centered example is padded with frame_size (4096) number
         # of samples, so we don't need to subtract that in that test.
-        for size, embedding in self.embeddings_ct.items():
-            assert embedding.shape == (64, 96000 // 256 + 1, int(size))
+        assert self.embeddings_ct.shape == (64, 96000 // 256 + 1, int(4096))
 
     def test_embeddings_nan(self):
         # Test for null values in the embeddings.
-        for embeddings in [self.embeddings_ct]:
-            for size, embedding in embeddings.items():
-                assert not torch.any(torch.isnan(embedding))
+        assert not torch.any(torch.isnan(self.embeddings_ct))
 
     def test_embeddings_type(self):
         # Test the data type of the embeddings.
-        for embeddings in [self.embeddings_ct]:
-            for size, embedding in embeddings.items():
-                if size != 20:
-                    assert embedding.dtype == torch.float32
-                else:
-                    assert embedding.dtype == torch.int8
+        assert self.embeddings_ct.dtype == torch.float32
 
     def test_timestamps_begin(self):
         # Test the beginning of the time stamp
@@ -176,10 +161,9 @@ class TestModel:
         outputs = self.model(self.frames)
         outputs_sliced = self.model(frames_sliced)
 
-        for output, output_sliced in zip(outputs.values(), outputs_sliced.values()):
-            assert torch.allclose(output_sliced[0], output[0])
-            assert torch.allclose(output_sliced[1], output[2])
-            assert torch.allclose(output_sliced, output[::2])
+        assert torch.allclose(outputs_sliced[0], outputs[0])
+        assert torch.allclose(outputs_sliced[1], outputs[2])
+        assert torch.allclose(outputs_sliced, outputs[::2])
 
 
 class TestFraming:

--- a/tests/test_baseline.py
+++ b/tests/test_baseline.py
@@ -5,7 +5,7 @@ Tests for the baseline model
 import numpy as np
 import torch
 
-from heareval.baseline import (
+from heareval.model.baseline import (
     load_model,
     get_audio_embedding,
     frame_audio,
@@ -17,8 +17,8 @@ torch.backends.cudnn.deterministic = True
 class TestEmbeddingsTimestamps:
     def setup(self):
         self.device = "cuda:0" if torch.cuda.is_available() else "cpu"
-        self.model, self.model_meta = load_model("basic", device=self.device)
-        self.sample_rate = self.model_meta["sample_rate"]
+        self.model = load_model(device=self.device)
+        self.sample_rate = self.model.sample_rate
         self.audio = torch.rand(64, 96000, device=self.device) * 2 - 1
         self.embeddings_ct, self.ts_ct = get_audio_embedding(
             audio=self.audio,
@@ -145,12 +145,18 @@ class TestEmbeddingsTimestamps:
 class TestModel:
     def setup(self):
         device = "cuda:0" if torch.cuda.is_available() else "cpu"
-        self.model, _ = load_model("basic", device=device)
+        self.model = load_model(device=device)
         self.frames = torch.rand(512, self.model.n_fft, device=device) * 2 - 1
 
     def teardown(self):
         del self.model
         del self.frames
+
+    def test_model_attributes(self):
+        # Each model should have sample_rate and embedding size information
+        assert hasattr(self.model, "sample_rate")
+        assert hasattr(self.model, "embedding_size")
+        assert hasattr(self.model, "version")
 
     def test_model_sliced(self):
         frames_sliced = self.frames[::2]

--- a/tests/test_baseline.py
+++ b/tests/test_baseline.py
@@ -157,7 +157,6 @@ class TestModel:
         # Each model should have sample_rate and embedding size information
         assert hasattr(self.model, "sample_rate")
         assert hasattr(self.model, "embedding_size")
-        assert hasattr(self.model, "version")
 
     def test_model_sliced(self):
         frames_sliced = self.frames[::2]


### PR DESCRIPTION
Updates to the current baseline model to and follow recent API updates:

- Model returns a single embedding now as opposed to a dictionary of embeddings
- `load_model()` returns a tuple of the loaded Model as well as a dictionary containing information including the sample_rate, embedding_size, and model version.
- prepping `load_model()` to also support loading learned model that @Luckygyana is working on
- `input_sample_rate()` has been removed since the sample_rate is now being returned in load_model()